### PR TITLE
Create reusable modal wrapper

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+interface ModalProps {
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function Modal({ onClose, children }: ModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center">
+      <div className="bg-white rounded-2xl max-w-lg w-full relative overflow-hidden">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-slate-500 hover:text-slate-900 text-xl font-bold"
+          aria-label="Close modal"
+        >
+          ×
+        </button>
+
+        <div className="p-6">{children}</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Created a reusable Modal component.

Added:
- onClose prop for closing the modal
- children prop using ReactNode
- dark backdrop with centered modal content
- close button inside the modal
- reusable white content box for future product details